### PR TITLE
Twitch arrangment of c#

### DIFF
--- a/courses/csharp/01-Introduction.md
+++ b/courses/csharp/01-Introduction.md
@@ -33,4 +33,5 @@
      - post an update to LinkedIn using #cs_internship #csharp tags.
      - post a tweet on Twitter using #cs_internship #csharp tags.
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
-  15. You should give a 20-min presentation about the content of this step, on Twitch platform.
+  15. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
+  16. You should give a 20-min presentation about the content of this step, on Twitch platform.

--- a/courses/csharp/02-Types.md
+++ b/courses/csharp/02-Types.md
@@ -15,4 +15,5 @@
      - post an update to LinkedIn using #cs_internship #csharp  
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
- 7. You should give a 20-min presentation about the content of this step, on Twitch platform.
+ 7. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
+ 8. You should give a 20-min presentation about the content of this step, on Twitch platform.

--- a/courses/csharp/03-Generics.md
+++ b/courses/csharp/03-Generics.md
@@ -20,4 +20,5 @@
      - post an update to LinkedIn using #cs_internship #csharp  
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
-  5. You should give a 20-min presentation about the content of this step, on Twitch platform.
+  5. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
+  6. You should give a 20-min presentation about the content of this step, on Twitch platform.

--- a/courses/csharp/04-Collections.md
+++ b/courses/csharp/04-Collections.md
@@ -19,4 +19,5 @@
     - post an update to LinkedIn using #cs_internship #csharp  
     - post a tweet on Twitter using #cs_internship #csharp
     - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags
- 5. You should give a 20-min presentation about the content of this step, on Twitch platform.
+ 5. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
+ 6. You should give a 20-min presentation about the content of this step, on Twitch platform.

--- a/courses/csharp/05-Inheritance.md
+++ b/courses/csharp/05-Inheritance.md
@@ -15,5 +15,6 @@
     - post an update to LinkedIn using #cs_internship #csharp  
     - post a tweet on Twitter using #cs_internship #csharp
     - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
- 4. You should give a 20-min presentation about the content of this step, on Twitch platform.
+ 4. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
+ 5. You should give a 20-min presentation about the content of this step, on Twitch platform.
 

--- a/courses/csharp/06-Object-LifeTime.md
+++ b/courses/csharp/06-Object-LifeTime.md
@@ -17,4 +17,5 @@
      - post an update to LinkedIn using #cs_internship #csharp  
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
- 5. You should give a 20-min presentation about the content of this step, on Twitch platform.
+ 5. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
+ 6. You should give a 20-min presentation about the content of this step, on Twitch platform.

--- a/courses/csharp/07-Exceptions.md
+++ b/courses/csharp/07-Exceptions.md
@@ -13,4 +13,5 @@
      - post an update to LinkedIn using #cs_internship #csharp  
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
-  3. You should give a 20-min presentation about the content of this step, on Twitch platform.
+  3. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
+  4. You should give a 20-min presentation about the content of this step, on Twitch platform.

--- a/courses/csharp/08-Delegates-Lambdas-Events.md
+++ b/courses/csharp/08-Delegates-Lambdas-Events.md
@@ -12,4 +12,5 @@
      - post an update to LinkedIn using #cs_internship #csharp  
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
- 3. You should give a 20-min presentation about the content of this step, on Twitch platform.
+ 3. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
+ 4. You should give a 20-min presentation about the content of this step, on Twitch platform.

--- a/courses/csharp/10-Asynchronous-Language-Features.md
+++ b/courses/csharp/10-Asynchronous-Language-Features.md
@@ -12,4 +12,5 @@
      - post an update to LinkedIn using #cs_internship #csharp  
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags
- 4. You should give a 20-min presentation about the content of this step, on Twitch platform.
+ 4. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
+ 5. You should give a 20-min presentation about the content of this step, on Twitch platform.

--- a/courses/csharp/11-C# New Features.md
+++ b/courses/csharp/11-C# New Features.md
@@ -21,3 +21,5 @@
   3. Find and introduce 2 libraries on GitHub which are C# 8.0 ready.
   4. Find a small GitHub project and help to make it to use C# 8.0 nullable reference types.
   5. Describe the situations that Pattern Matching helps. How does it help?
+  6. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
+  7. You should give a 20-min presentation about the content of this step, on Twitch platform.

--- a/courses/csharp/9-LINQ.md
+++ b/courses/csharp/9-LINQ.md
@@ -17,4 +17,5 @@
      - post an update to LinkedIn using #cs_internship #csharp  
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags
- 5. You should give a 20-min presentation about the content of this step, on Twitch platform.
+ 5. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
+ 6. You should give a 20-min presentation about the content of this step, on Twitch platform.

--- a/meetings/meeting-entrance-interview.md
+++ b/meetings/meeting-entrance-interview.md
@@ -36,12 +36,16 @@ This is the frist and the most important interview with a new intern. If the int
    - Never ever break it!
    - 2 sides of the rule.
    - Applies to all aspects of our work: from a simple Skype meeting to accomplishing task within a sprint.
-5. **The Mentorship Process** It should be clarified for them that they are required to contribute to this internship at some point due to two reasons (note that the reasons should be stated in this interview as well): 
-   1. A large portion of learning process (both for technology and soft skills) are acquired through mentorship which in turn includes helping the interns and also fulfilling some tasks assigned to them in the sprint sessions.
-   2. The interns should be told that this internship is free of charge, but we only request them to do one thing in return; to be part of this internship and help the new comers to learn. 
-6. **The Learning Process -** How do we work
+
+5. **The Learning Process -** How do we work
    - Steps
    - Agree to be active on Twitter and LinkedIn
+
+6. **The Mentorship Process** It should be clarified for them that they are required to contribute to this internship at some point due to two reasons (note that the reasons should be stated in this interview as well): 
+   1. A large portion of learning process (both for technology and soft skills) are acquired through mentorship which in turn includes helping the interns and also fulfilling some tasks assigned to them in the sprint sessions.
+   2. The interns should be told that this internship is free of charge because of the help of mentors who were formerly interns. Having new interns contribute to the progress and evolution of cs internship by becoming mentors, is a necessity to have the course remain free. So new interns are required to be part of this internship and  help the new comers to learn.
+   
+   
 7. **The Promise -** Clarifying the required commitment:
    - The promise of ***9 months***: This plan will be the highest priority within this period.
    - The promise of ***Weekly hours***: Integrity starts here.
@@ -55,5 +59,12 @@ The qualified instructors for this document:
  - Shahryar
 
 # Instructor Notes
-[TO BE COMPLETED]
+1. Interviewers should first comprehense the goal of mentorship and values gained through it, to be successful interviewers. 
+2. Interviewers should clarify what is meant by the word mentorship. 
+3. Recommanded way to inform the intern about concepts of mentorship and integrity to  
+**first**: inform them what we want to achieve: having working teams.  
+**second**: inform them what we need to achieve our goal: soft skills.  
+**third**: inform them how we manage to gain those skills: mentorship and preserving integrity.  
+4. Attendees of this meeting should be informed that the meeting is being recorded. Mentors should record the meeting and upload it to _`Mentor's Feed`_ Telegram channel with the `#interview` hashtag
+
 # FAQ


### PR DESCRIPTION
Interns will have a task that requires them to ask their mentors to arrange a twitch time for them exactly 7 days before their deadline. 
Mentors will have to set calendar for the twitch, ( on the shared calendar of the course)
