### PR TITLE
Update twitch task for recording and publishing presentations

### DIFF
--- a/courses/csharp/01-Introduction.md
+++ b/courses/csharp/01-Introduction.md
@@ -34,4 +34,4 @@
      - post a tweet on Twitter using #cs_internship #csharp tags.
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
   15. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  16. You should give a 20-min presentation about the content of this step, on Twitch platform. And it will be published on CS Internship Youtube channel. 
+  16. You should give a 20-min presentation about the content of this step, on Twitch platform. And it will be published on CS Internship Youtube channel. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/csharp/01-Introduction.md
+++ b/courses/csharp/01-Introduction.md
@@ -34,4 +34,4 @@
      - post a tweet on Twitter using #cs_internship #csharp tags.
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
   15. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  16. You should give a 20-min presentation about the content of this step, on Twitch platform.
+  16. You should give a 20-min presentation about the content of this step, on Twitch platform. And it will be published on CS Internship Youtube channel. 

--- a/courses/csharp/01-Introduction.md
+++ b/courses/csharp/01-Introduction.md
@@ -34,4 +34,4 @@
      - post a tweet on Twitter using #cs_internship #csharp tags.
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
   15. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  16. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+  16. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/csharp/01-Introduction.md
+++ b/courses/csharp/01-Introduction.md
@@ -34,4 +34,4 @@
      - post a tweet on Twitter using #cs_internship #csharp tags.
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
   15. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  16. You should give a 20-min presentation about the content of this step, on Twitch platform. And it will be published on CS Internship Youtube channel. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+  16. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/csharp/02-Types.md
+++ b/courses/csharp/02-Types.md
@@ -16,4 +16,4 @@
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
  7. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 8. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+ 8. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/csharp/02-Types.md
+++ b/courses/csharp/02-Types.md
@@ -16,4 +16,4 @@
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
  7. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 8. You should give a 20-min presentation about the content of this step, on Twitch platform.
+ 8. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/csharp/03-Generics.md
+++ b/courses/csharp/03-Generics.md
@@ -21,4 +21,4 @@
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
   5. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  6. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+  6. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/csharp/03-Generics.md
+++ b/courses/csharp/03-Generics.md
@@ -21,4 +21,4 @@
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
   5. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  6. You should give a 20-min presentation about the content of this step, on Twitch platform.
+  6. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/csharp/04-Collections.md
+++ b/courses/csharp/04-Collections.md
@@ -20,4 +20,4 @@
     - post a tweet on Twitter using #cs_internship #csharp
     - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags
  5. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 6. You should give a 20-min presentation about the content of this step, on Twitch platform.
+ 6. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/csharp/04-Collections.md
+++ b/courses/csharp/04-Collections.md
@@ -20,4 +20,4 @@
     - post a tweet on Twitter using #cs_internship #csharp
     - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags
  5. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 6. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+ 6. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/csharp/05-Inheritance.md
+++ b/courses/csharp/05-Inheritance.md
@@ -16,5 +16,4 @@
     - post a tweet on Twitter using #cs_internship #csharp
     - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
  4. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 5. You should give a 20-min presentation about the content of this step, on Twitch platform.
-
+ 5. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/csharp/05-Inheritance.md
+++ b/courses/csharp/05-Inheritance.md
@@ -16,4 +16,4 @@
     - post a tweet on Twitter using #cs_internship #csharp
     - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
  4. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 5. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+ 5. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/csharp/06-Object-LifeTime.md
+++ b/courses/csharp/06-Object-LifeTime.md
@@ -18,4 +18,4 @@
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
  5. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 6. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+ 6. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/csharp/06-Object-LifeTime.md
+++ b/courses/csharp/06-Object-LifeTime.md
@@ -18,4 +18,4 @@
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
  5. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 6. You should give a 20-min presentation about the content of this step, on Twitch platform.
+ 6. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/csharp/07-Exceptions.md
+++ b/courses/csharp/07-Exceptions.md
@@ -14,4 +14,4 @@
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
   3. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  4. You should give a 20-min presentation about the content of this step, on Twitch platform.
+  4. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/csharp/07-Exceptions.md
+++ b/courses/csharp/07-Exceptions.md
@@ -14,4 +14,4 @@
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
   3. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  4. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+  4. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/csharp/08-Delegates-Lambdas-Events.md
+++ b/courses/csharp/08-Delegates-Lambdas-Events.md
@@ -13,4 +13,4 @@
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
  3. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 4. You should give a 20-min presentation about the content of this step, on Twitch platform.
+ 4. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/csharp/08-Delegates-Lambdas-Events.md
+++ b/courses/csharp/08-Delegates-Lambdas-Events.md
@@ -13,4 +13,4 @@
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags.
  3. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 4. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+ 4. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/csharp/10-Asynchronous-Language-Features.md
+++ b/courses/csharp/10-Asynchronous-Language-Features.md
@@ -13,4 +13,4 @@
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags
  4. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 5. You should give a 20-min presentation about the content of this step, on Twitch platform.
+ 5. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/csharp/10-Asynchronous-Language-Features.md
+++ b/courses/csharp/10-Asynchronous-Language-Features.md
@@ -13,4 +13,4 @@
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags
  4. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 5. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+ 5. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/csharp/11-C# New Features.md
+++ b/courses/csharp/11-C# New Features.md
@@ -22,4 +22,4 @@
   4. Find a small GitHub project and help to make it to use C# 8.0 nullable reference types.
   5. Describe the situations that Pattern Matching helps. How does it help?
   6. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  7. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+  7. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/csharp/11-C# New Features.md
+++ b/courses/csharp/11-C# New Features.md
@@ -22,4 +22,4 @@
   4. Find a small GitHub project and help to make it to use C# 8.0 nullable reference types.
   5. Describe the situations that Pattern Matching helps. How does it help?
   6. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  7. You should give a 20-min presentation about the content of this step, on Twitch platform.
+  7. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/csharp/9-LINQ.md
+++ b/courses/csharp/9-LINQ.md
@@ -18,4 +18,4 @@
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags
  5. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 6. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+ 6. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/csharp/9-LINQ.md
+++ b/courses/csharp/9-LINQ.md
@@ -18,4 +18,4 @@
      - post a tweet on Twitter using #cs_internship #csharp
      - post on 'CS Internship - C# Club' telegram groupe using #cs_internship #csharp tags
  5. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 6. You should give a 20-min presentation about the content of this step, on Twitch platform.
+ 6. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/python/01-Introduction.md
+++ b/courses/python/01-Introduction.md
@@ -29,4 +29,4 @@
   11. Solve problems 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.24, 1.25, 1.34, 1.36, 1.43, 1.47, 1.58, and 1.59 from chapter **one** in **[No bullshit guide to linear algebra](README.md)** **(Theorical problems)**.
   12. Find at least 5 other useful online resources for python and explain why you chose them.
   13. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  14. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+  14. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/python/01-Introduction.md
+++ b/courses/python/01-Introduction.md
@@ -29,4 +29,4 @@
   11. Solve problems 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.24, 1.25, 1.34, 1.36, 1.43, 1.47, 1.58, and 1.59 from chapter **one** in **[No bullshit guide to linear algebra](README.md)** **(Theorical problems)**.
   12. Find at least 5 other useful online resources for python and explain why you chose them.
   13. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  14. You should give a 20-min presentation about the content of this step, on Twitch platform.
+  14. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/python/02-Collection and Control Flows.md
+++ b/courses/python/02-Collection and Control Flows.md
@@ -25,4 +25,4 @@
   5. Solve problems 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 2.10, and 2.11 from chapter **two** and problems 3.1, 3.3, and 3.4 from chapter **three** in **[No bullshit guide to linear algebra](README.md)** **(Theorical problems)**.
   6. Follow at least 3 people on LinkedIn and 5 people (or accounts) on Twitter that are active and famous on Python.
   7. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  8. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+  8. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/python/02-Collection and Control Flows.md
+++ b/courses/python/02-Collection and Control Flows.md
@@ -25,4 +25,4 @@
   5. Solve problems 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 2.10, and 2.11 from chapter **two** and problems 3.1, 3.3, and 3.4 from chapter **three** in **[No bullshit guide to linear algebra](README.md)** **(Theorical problems)**.
   6. Follow at least 3 people on LinkedIn and 5 people (or accounts) on Twitter that are active and famous on Python.
   7. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  8. You should give a 20-min presentation about the content of this step, on Twitch platform.
+  8. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/python/03-Scopes and Classes.md
+++ b/courses/python/03-Scopes and Classes.md
@@ -21,4 +21,4 @@
       - Tournament
   5. Solve problems 4.1, 4.6, 4.7, 4.8, 4.10, 4.11, 4.12, 4.13, 4.18, 4.21, and 4.26 from chapetr **four** in **[No bullshit guide to linear algebra](README.md)** **(Theorical problems)**.
   6. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  7. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+  7. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/python/03-Scopes and Classes.md
+++ b/courses/python/03-Scopes and Classes.md
@@ -21,4 +21,4 @@
       - Tournament
   5. Solve problems 4.1, 4.6, 4.7, 4.8, 4.10, 4.11, 4.12, 4.13, 4.18, 4.21, and 4.26 from chapetr **four** in **[No bullshit guide to linear algebra](README.md)** **(Theorical problems)**.
   6. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  7. You should give a 20-min presentation about the content of this step, on Twitch platform.
+  7. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/python/04-Files and Exceptions.md
+++ b/courses/python/04-Files and Exceptions.md
@@ -16,5 +16,4 @@
  4. Pass all lessons on TypingClub.com **with 5 stars** up to **lesson 233**.
  5. Download EURUSD forex data from [this](https://www.histdata.com/download-free-forex-historical-data/?/excel/1-minute-bar-quotes/eurusd/2018) link and then extract and open it with proper Python commands.
  6. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 7. You should give a 20-min presentation about the content of this step, on Twitch platform.
-
+ 7. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/python/04-Files and Exceptions.md
+++ b/courses/python/04-Files and Exceptions.md
@@ -16,4 +16,4 @@
  4. Pass all lessons on TypingClub.com **with 5 stars** up to **lesson 233**.
  5. Download EURUSD forex data from [this](https://www.histdata.com/download-free-forex-historical-data/?/excel/1-minute-bar-quotes/eurusd/2018) link and then extract and open it with proper Python commands.
  6. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 7. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+ 7. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/python/05-Numpy.md
+++ b/courses/python/05-Numpy.md
@@ -17,4 +17,4 @@ This SO post can help you in case you get blocked from voting before reaching th
     - Use your GitHub as source control.
  5. Find at least 5 other online resources about numpy, and explain why you chose them.
  6. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 7. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+ 7. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/python/05-Numpy.md
+++ b/courses/python/05-Numpy.md
@@ -17,4 +17,4 @@ This SO post can help you in case you get blocked from voting before reaching th
     - Use your GitHub as source control.
  5. Find at least 5 other online resources about numpy, and explain why you chose them.
  6. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 7. You should give a 20-min presentation about the content of this step, on Twitch platform.
+ 7. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/python/06-Pandas-Matplotlib.md
+++ b/courses/python/06-Pandas-Matplotlib.md
@@ -17,4 +17,4 @@
     - Use your GitHub as source control.  
  7. Find at least 5 other online resources about pandas & matplotlib, and explain why you chose them.
  8. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 9. You should give a 20-min presentation about the content of this step, on Twitch platform.
+ 9. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/python/06-Pandas-Matplotlib.md
+++ b/courses/python/06-Pandas-Matplotlib.md
@@ -17,4 +17,4 @@
     - Use your GitHub as source control.  
  7. Find at least 5 other online resources about pandas & matplotlib, and explain why you chose them.
  8. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
- 9. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+ 9. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/web/01-HTML-CSS-Basics.md
+++ b/courses/web/01-HTML-CSS-Basics.md
@@ -26,4 +26,4 @@
 11. Achieve [**Informed**](https://stackoverflow.com/help/badges/2600/informed) badge on StackOverflow.
 12. Find at least 5 other useful online resources for each HTML/CSS and Git/Github and explain why you chose them.
 13. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-14. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+14. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/web/01-HTML-CSS-Basics.md
+++ b/courses/web/01-HTML-CSS-Basics.md
@@ -26,4 +26,4 @@
 11. Achieve [**Informed**](https://stackoverflow.com/help/badges/2600/informed) badge on StackOverflow.
 12. Find at least 5 other useful online resources for each HTML/CSS and Git/Github and explain why you chose them.
 13. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-14. You should give a 20-min presentation about the content of this step, on Twitch platform.
+14. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/web/02-JS-Basics.md
+++ b/courses/web/02-JS-Basics.md
@@ -41,4 +41,4 @@
 10. Name 5 useful Web libraries and describe what they do and why they're good. Give a star to their GitHub repo.
 11. Find at least 5 other online resources about JS and explain why you chose them.
 12. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-13. You should give a 20-min presentation about the content of this step, on Twitch platform.
+13. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/web/02-JS-Basics.md
+++ b/courses/web/02-JS-Basics.md
@@ -41,4 +41,4 @@
 10. Name 5 useful Web libraries and describe what they do and why they're good. Give a star to their GitHub repo.
 11. Find at least 5 other online resources about JS and explain why you chose them.
 12. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-13. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+13. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/web/03-Web-In-Practice-1-Client.md
+++ b/courses/web/03-Web-In-Practice-1-Client.md
@@ -36,7 +36,7 @@
 9. Pass all lessons on TypingClub.com with 5 stars up to **lesson 191**.
 10. Find at least 5 other online resources about client side JS & Tooling, and explain why you chose them. 
 11. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-12. You should give a 20-min presentation about the content of this step, on Twitch platform.
+12. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
 
 
 ## Instructors <!-- omit in toc -->

--- a/courses/web/03-Web-In-Practice-1-Client.md
+++ b/courses/web/03-Web-In-Practice-1-Client.md
@@ -36,7 +36,7 @@
 9. Pass all lessons on TypingClub.com with 5 stars up to **lesson 191**.
 10. Find at least 5 other online resources about client side JS & Tooling, and explain why you chose them. 
 11. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-12. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+12. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.
 
 
 ## Instructors <!-- omit in toc -->

--- a/courses/web/04-Web-In-Practice-2-Http-Server.md
+++ b/courses/web/04-Web-In-Practice-2-Http-Server.md
@@ -29,4 +29,4 @@
 9. Achieve [**Teacher**](https://stackoverflow.com/help/badges/1/teacher) badge on StackOverflow.
 10. Find at least 5 other online resources about **Http** & **NodeJs** and explain why you chose them.
 11. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-12. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+12. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.

--- a/courses/web/04-Web-In-Practice-2-Http-Server.md
+++ b/courses/web/04-Web-In-Practice-2-Http-Server.md
@@ -29,4 +29,4 @@
 9. Achieve [**Teacher**](https://stackoverflow.com/help/badges/1/teacher) badge on StackOverflow.
 10. Find at least 5 other online resources about **Http** & **NodeJs** and explain why you chose them.
 11. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-12. You should give a 20-min presentation about the content of this step, on Twitch platform.
+12. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/web/05-Web-In-Practice-3-Security.md
+++ b/courses/web/05-Web-In-Practice-3-Security.md
@@ -31,4 +31,4 @@
 6. Achieve [**Self Learner**](https://stackoverflow.com/help/badges/14/self-learner) badge on StackOverflow.
 7. Find at least 5 other online resources about **Authentication in Web** and explain why you chose them, then share them on Twitter and LinkedIn.
 8. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day. 
-9. You should give a 20-min presentation about the content of this step, on Twitch platform.
+9. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.

--- a/courses/web/05-Web-In-Practice-3-Security.md
+++ b/courses/web/05-Web-In-Practice-3-Security.md
@@ -31,4 +31,4 @@
 6. Achieve [**Self Learner**](https://stackoverflow.com/help/badges/14/self-learner) badge on StackOverflow.
 7. Find at least 5 other online resources about **Authentication in Web** and explain why you chose them, then share them on Twitter and LinkedIn.
 8. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day. 
-9. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your presentation live and give it to your mentor which will then be published on the CS Internship YouTube channel.
+9. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.


### PR DESCRIPTION
From now on, interns should record each presentation live and send it to their mentors. Then the record will be published on CS Internship channel on YouTube.