### PR TITLE
changed a link and edited some grammatical errors

### DIFF
--- a/courses/csharp/11-C# New Features.md
+++ b/courses/csharp/11-C# New Features.md
@@ -16,7 +16,7 @@
 
 ### Study Items
 
-  1. [What's new in C# 6.0](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-6)
+  1. [What's new in C# 6.0](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history#c-version-60)
   2. [What's new in C# 7.0](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7)
   3. [What's new in C# 7.1](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7-1)
   4. [What's new in C# 7.2](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7-2)
@@ -32,9 +32,9 @@
 
   1. Find and introduce 2 blog posts about how people experienced upgrading their projects to support new C# 8.0 nullable reference types.
   2. Pass all lessons on TypingClub.com **with 5 stars** up to lesson 429.
-  3. In your opinion, what's the most big challenges in upgradint to C# 8.0?
+  3. In your opinion, what's the biggest challenge in upgrading to C# 8.0?
   4. Find and introduce 2 libraries on GitHub which are C# 8.0 ready.
-  5. Find a small GitHub project and help to make it to use C# 8.0 nullable reference types.
+  5. Find a small GitHub project and help to make it use C# 8.0 nullable reference types.
   6. Describe the situations that Pattern Matching helps. How does it help?
   7. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
-  8. You should give a 20-min presentation about the content of this step, on Twitch platform. You should record your twitch at the time of presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.
+  8. You should give a 20-min presentation about the content of this step, on the Twitch platform. You should record your twitch at the time of the presentation and send it to your mentor with a brief explanation of the topic. All twitches will be published on the CS Internship YouTube channel.


### PR DESCRIPTION
1. In the study item 1 changed the link from the C# 9.0 new items page to the C# 6.0 new items in the C# version history page.
2. In the study item 3 changed <the most big> to <the biggest> and <challenges> to <challenge> 
3. In the study item 5 omited the <to> before <use>.
4. In the study item 8 added a <the> before <Twitch> and a <the> before <presentation> as well.