### PR TITLE
Adding intern categories for the interview and the problem check sessions

### DIFF
--- a/meetings/meeting-entrance-interview.md
+++ b/meetings/meeting-entrance-interview.md
@@ -9,10 +9,15 @@
 ## Interview Process
 This is the frist and the most important interview with a new intern. If the intern says yes he/she should really mean it based on a really important decsion in her/his life!
 
-1. Initiates by a mentor: 
+- Initiates by a mentor: 
    1. Mentor arranges a Skype meeting.
    2. While arranging a meeting, mentor has the chance to break the ice with the intern and get friends.
-2. Attendees: Interviewer, Observer (Mentor), Intern 1, Intern 2 (optional)
+
+- Attendees: Interviewer, Observer (Mentor), Intern 1, Intern 2 (optional)
+
+- Interns attending the interview fit into one of these two categories:
+     1. Those who are being interviewed for the first time. Based on the order of applicants in the queue, it's now their turn to start the process of entering a course.
+     2. Those who had been interviewed before, but their statement commitment had not been verified successfully.
 
 ## Interview Meeting Content
 ### Goals

--- a/meetings/meeting-problem-check.md
+++ b/meetings/meeting-problem-check.md
@@ -5,6 +5,10 @@ In our team, there is no place for someone without *Commitment* and *Integrity*.
 
 This meeting will be hold if we believe someone is threatenting our team's integrity. In another word, we hold this meeting if we feel a crisis in our team. 
 
+Interns attending a problem check session fit into one of these two categories:
+1. Those who are considered as having commitment and integrity issues.
+2. Those who had been attending a course in the CS Internship before, but had to leave due to integrity failure, and now are willing to join again.
+
 ## Goals
 This meeting has specific goals as described below. The intern:
  - Should understand the complete story of her/his problem.


### PR DESCRIPTION
According to some decisions about people who are rejoining CS Internship (those who had left the internship for some reason and now are willing to join again), the interview and the problem check doc needed to be updated to include the two types of interns being interviewed or attending the problem check session.