### PR TITLE
Correcting the links of data for task 3 of steps 9 and 10.

### DIFF
--- a/courses/Machine Learning/09-Unsupervised-Learning-Task.md
+++ b/courses/Machine Learning/09-Unsupervised-Learning-Task.md
@@ -24,7 +24,7 @@
 
  1. Achieve [**Vox Populi**](https://stackoverflow.com/help/badges/1108/vox-populi) badge on StackOverflow.
  2. Pass all lessons on TypingClub.com **with 5 stars** up to **lesson 374**.
- 3. Build a model to detect fraudulent activities [(data)](https://www.kaggle.com/code/msantrod/the-enron-scandal-a-fraud-detection-project/input?select=emails.csv).
+ 3. Build a model to detect fraudulent activities [(data)](https://www.cs.cmu.edu/~enron/).
  4. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
  5. You should give a 20-min presentation about the content of this step, on Linkedin live platform. You should record your Linkedin live at the time of presentation and send it to your mentor with a brief explanation of the topic. All Linkedin live presentations will be published on the CS Internship YouTube channel.
 

--- a/courses/Machine Learning/09-Unsupervised-Learning-Task.md
+++ b/courses/Machine Learning/09-Unsupervised-Learning-Task.md
@@ -24,7 +24,7 @@
 
  1. Achieve [**Vox Populi**](https://stackoverflow.com/help/badges/1108/vox-populi) badge on StackOverflow.
  2. Pass all lessons on TypingClub.com **with 5 stars** up to **lesson 374**.
- 3. Build a model to detect fraudulent activities [(data)](https://www.cs.cmu.edu/~enron/).
+ 3. Build a model to detect fraudulent activities [(data)](https://www.kaggle.com/code/msantrod/the-enron-scandal-a-fraud-detection-project/input?select=emails.csv).
  4. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
  5. You should give a 20-min presentation about the content of this step, on Linkedin live platform. You should record your Linkedin live at the time of presentation and send it to your mentor with a brief explanation of the topic. All Linkedin live presentations will be published on the CS Internship YouTube channel.
 

--- a/courses/Machine Learning/10-Neural-Networks-Definition.md
+++ b/courses/Machine Learning/10-Neural-Networks-Definition.md
@@ -24,7 +24,7 @@
 
  1. Achieve [**Self-Learner**](https://stackoverflow.com/help/badges/14/self-learner) badge on StackOverflow.
  2. Pass all lessons on TypingClub.com **with 5 stars** up to **lesson 388**.
- 3. Create a neural network by machine learning to read and detect [handwriting data](https://archive.ics.uci.edu/ml/datasets/Pen-Based+Recognition+of+Handwritten+Digits).
+ 3. Create a neural network by machine learning to read and detect [handwriting data](https://archive.ics.uci.edu/dataset/81/pen+based+recognition+of+handwritten+digits).
  4. Exactly **7 days** before your deadline, ask your mentor to arrange a twitch time for you on your deadline day.
  5. You should give a 20-min presentation about the content of this step, on Linkedin live platform. You should record your Linkedin live at the time of presentation and send it to your mentor with a brief explanation of the topic. All Linkedin live presentations will be published on the CS Internship YouTube channel.
 


### PR DESCRIPTION
Links of the datasets for task 3 of steps 9 and 10 were updated to correct links.
Step 9 link was changed from "https://www.cs.cmu.edu/~enron/" to "https://www.kaggle.com/code/msantrod/the-enron-scandal-a-fraud-detection-project/input?select=emails.csv" and step 10 link was changed from "https://archive.ics.uci.edu/ml/datasets/Pen-Based+Recognition+of+Handwritten+Digits" to "https://archive.ics.uci.edu/dataset/81/pen+based+recognition+of+handwritten+digits".